### PR TITLE
Prepare for Nextcloud appstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,20 @@
-owncloud-checksum
-=================
+Checksum
+========
 
-Owncloud Plugin to create md5-hashes of files.
-
+**Plugin for [Nextcloud](https://nextcloud.com) and owncloud to create md5-hashes of files.**
 
 Installation
 ------------
 
-- Copy the checksum folder in the app directory of owncloud.
-- If not already done, rename the app-folder to "checksum" - causes overwise an sql error.
-- Enable this app in the admin interface.
-
+In your Instance, simply navigate to »Apps«, choose the category »Files«, find the Checksum app and enable it.
 
 Usage
 -----
 
-Open the details view. There should be a new tab called "Checksum". Select a hashalgorithm and it will try to generate a hash.
+Just open the details view of the file (Sidebar). There should be a new tab called "Checksum". Select a algorithm and it will try to generate a hash.
 
+Compatibility
+-------------
 
-Notice
-------
-
-- I only tested the app for the current version of owncloud (9.x). I tried to use the current api as much as possible. It should be safe for future versions.
-- Tested and worked with Nextcloud 10.x too. 
+- I only tested the app for the current version of owncloud (9.x) and Nextcloud 10 and 11.
+- I tried to use the current api as much as possible. It should be safe for future versions.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 Checksum
 ========
 
-**Plugin for [Nextcloud](https://nextcloud.com) and owncloud to create md5-hashes of files.**
+**Plugin for [Nextcloud](https://nextcloud.com) and [ownCloud](https://owncloud.org) to create hashes of files.**
 
 Installation
 ------------
 
+**Nextcloud**
+
 In your Instance, simply navigate to »Apps«, choose the category »Files«, find the Checksum app and enable it.
+
+**ownCloud**
+- Copy the checksum folder in the app directory of owncloud.
+- If not already done, rename the app-folder to "checksum" - causes overwise an sql error.
+- Enable this app in the admin interface.
 
 Usage
 -----

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,15 +1,22 @@
 <?xml version="1.0"?>
-<info>
+<info xmlns:xsi= "http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
     <id>checksum</id>
     <name>Checksum</name>
+    <summary>Creating a hash checksum of a file.</summary>
     <description>Creating a hash checksum of a file.</description>
-    <version>0.3</version>
-    <licence>AGPL</licence>
+    <version>0.3.1</version>
+    <licence>agpl</licence>
     <author>westberliner</author>
     <types>
       <filesystem/>
     </types>
+    <category>files</category>
+    <category>tools</category>
+    <website>https://github.com/westberliner/owncloud-checksum/</website>
+    <bugs>https://github.com/westberliner/owncloud-checksum/issues</bugs>
     <dependencies>
         <owncloud min-version="9.0" max-version="11" />
+        <nextcloud min-version="9" max-version="12" />
     </dependencies>
 </info>


### PR DESCRIPTION
Since Nextcloud 11 uses its own App Store (https://apps.nextcloud.com) it would be nice, if you could publish your app there too - so that our community can benefit of this nice addition 👊 

- Adjust `info.xml` for the Nextcloud appstore
- Polishing the `README.md` a bit 

You will find out more about how to publish this app in the Nextcloud appstore over here: https://nextcloudappstore.readthedocs.io/en/latest/developer.html

If you need any help, feel free to ask 😉 @westberliner 

Signed-off-by: Marius Blüm <marius@lineone.io>