### PR TITLE
changed the documentation-links to master

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,8 +14,8 @@
     </description>
     <screenshot>https://raw.githubusercontent.com/westberliner/owncloud-checksum/master/screenshots/checksum.gif</screenshot>
     <documentation>
-        <user>https://github.com/westberliner/owncloud-checksum/blob/v0.3.4/README.md</user>
-        <admin>https://github.com/westberliner/owncloud-checksum/blob/v0.3.4/README.md</admin>
+        <user>https://github.com/westberliner/owncloud-checksum/blob/master/README.md</user>
+        <admin>https://github.com/westberliner/owncloud-checksum/blob/master/README.md</admin>
     </documentation>
     <version>0.3.5</version>
     <licence>agpl</licence>


### PR DESCRIPTION
i'm pretty sure this is better choice, since they haven't to be changed for every release and also the links in the app-store shouldn't be grounded to one version.