### PR TITLE
Bump Nextcloud version to 13

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,6 +29,6 @@
     <bugs>https://github.com/westberliner/owncloud-checksum/issues</bugs>
     <dependencies>
         <owncloud min-version="9.0" max-version="11" />
-        <nextcloud min-version="9" max-version="12" />
+        <nextcloud min-version="9" max-version="13" />
     </dependencies>
 </info>


### PR DESCRIPTION
Change the max allowed version of Nextcloud to make it work with 13.
I tried it on my Nextcloud 13 Beta 3, no problems so far.